### PR TITLE
Handle non-name phrases when parsing contacts

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -2,6 +2,11 @@ import re
 
 class Contacts:
     contacts = 0
+    # Common phrases that might look like names but aren't
+    NON_NAME_PHRASES = [
+        "לפרטים נוספים",
+        "כתובת דואר אלקטרוני",
+    ]
 
     def __init__(self, raw_text, city):
         self.raw_text = raw_text
@@ -60,11 +65,33 @@ class Contacts:
                 self.role = word
                 break
 
-        # Try to extract full Hebrew name
+        # Try to extract full Hebrew name first
+        candidate = None
         name_candidates = re.findall(r"[א-ת]{2,}(?:\s+[א-ת\"׳]{2,})+", self.raw_text)
         if name_candidates:
-            self.name = name_candidates[0]
-        else:
+            candidate = name_candidates[0].strip()
+
+        # If no full name found, fall back to a single Hebrew word (first name)
+        if not candidate:
+            first_match = re.search(r"\b[א-ת]{2,}\b", self.raw_text)
+            if first_match:
+                candidate = first_match.group(0).strip()
+
+        if candidate and not any(candidate in phrase or phrase in candidate for phrase in Contacts.NON_NAME_PHRASES):
+            self.name = candidate
+
+        # Fall back to email-derived name if no Hebrew name detected
+        if not self.name and self.email:
+            # Skip when text contains known non-name phrases
+            if not any(phrase in self.raw_text for phrase in Contacts.NON_NAME_PHRASES):
+                local = self.email.split('@')[0]
+                parts = re.split(r'[._-]+', local)
+                parts = [p for p in parts if p.isalpha()]
+                non_personal = {"info", "contact", "office", "admin", "support", "service", "team", "mail", "email", "example"}
+                if parts and all(p.lower() not in non_personal for p in parts):
+                    self.name = " ".join(p.capitalize() for p in parts)
+
+        if not self.name:
             self.name = f"לא נמצא שם ({self.role})" if self.role else "לא נמצא שם"
 
     def to_dict(self):

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -21,6 +21,14 @@ def test_contact_mobile_only():
     assert c.email == "dani@test.org"
     assert c.phone_mobile == "058765432"
     assert c.phone_office is None
+    assert c.name == "דני"
+
+
+def test_first_name_only():
+    text = "צבי 05-5555555"
+    c = Contacts(text, "גבעתיים")
+    assert c.name == "צבי"
+    assert c.phone_mobile == "055555555"
 
 
 def test_contact_office_only():
@@ -29,3 +37,27 @@ def test_contact_office_only():
     assert c.email == "sarah@domain.com"
     assert c.phone_mobile is None
     assert c.phone_office == "031234567"
+
+
+def test_non_name_phrase_lifratim_nosefim():
+    text = "לפרטים נוספים נא לפנות example@example.com"
+    c = Contacts(text, "אשדוד")
+    assert c.name == "לא נמצא שם"
+
+
+def test_non_name_phrase_email_address():
+    text = "כתובת דואר אלקטרוני info@test.com"
+    c = Contacts(text, "באר שבע")
+    assert c.name == "לא נמצא שם"
+
+
+def test_name_from_email():
+    text = "noa_adari@example.org"
+    c = Contacts(text, "אשקלון")
+    assert c.name == "Noa Adari"
+
+
+def test_non_personal_email_ignored():
+    text = "info@example.org"
+    c = Contacts(text, "אשקלון")
+    assert c.name == "לא נמצא שם"


### PR DESCRIPTION
## Summary
- avoid treating common Hebrew phrases as names
- test new name filtering logic
- fix corrupted tests file
- support single-word names when no surname is present
- parse name from email addresses when no Hebrew name is found

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6851d4fc7e008321b1f1c0262c576e67