### PR TITLE
Add name pull utility

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -50,6 +50,21 @@ def _load_name_db() -> set[str]:
 
 ISRAELI_NAME_DB = _load_name_db()
 
+# Mapping of English keywords to their Hebrew department names. This allows
+# detecting the department from contact lines that use English terms.
+ENGLISH_DEPT_KEYWORDS = {
+    "youth": "מחלקת נוער",
+    "young": "מחלקת צעירים",
+    "culture": "מחלקת תרבות",
+    "events": "מחלקת אירועים",
+    "education": "מחלקת חינוך",
+    "community": "מחלקת קהילה",
+    "welfare": "מחלקת רווחה",
+    "absorption": "מחלקת קליטה",
+    "environment": "מחלקת איכות סביבה",
+    "veterans": "מחלקת אזרחים וותיקים",
+}
+
 class Contacts:
     contacts = 0
     # Common phrases that might look like names but aren't
@@ -136,6 +151,14 @@ class Contacts:
             if keyword in self.raw_text:
                 self.department = dept
                 break
+
+        # If no Hebrew keyword matched, look for English department keywords
+        if not self.department:
+            lower_text = self.raw_text.lower()
+            for keyword, dept in ENGLISH_DEPT_KEYWORDS.items():
+                if keyword in lower_text:
+                    self.department = dept
+                    break
 
         # Try to guess role from line
         possible_roles = [

--- a/src/name_pull.py
+++ b/src/name_pull.py
@@ -1,0 +1,145 @@
+# Utility for collecting unique names from scraping logs and transliterating
+# them to Hebrew if they are written in English letters.
+
+from __future__ import annotations
+import json
+import os
+import re
+from pathlib import Path
+
+from jobs import Contacts
+
+
+LATIN_TO_HEBREW = {
+    "a": "א",
+    "b": "ב",
+    "c": "ק",
+    "d": "ד",
+    "e": "י",
+    "f": "פ",
+    "g": "ג",
+    "h": "ה",
+    "i": "י",
+    "j": "ג",
+    "k": "ק",
+    "l": "ל",
+    "m": "מ",
+    "n": "נ",
+    "o": "ו",
+    "p": "פ",
+    "q": "ק",
+    "r": "ר",
+    "s": "ס",
+    "t": "ט",
+    "u": "ו",
+    "v": "ו",
+    "w": "ו",
+    "x": "קס",
+    "y": "י",
+    "z": "ז",
+}
+
+# Final forms for certain Hebrew letters when they appear at the end of a word
+FINAL_FORMS = {
+    "m": "ם",
+    "n": "ן",
+    "p": "ף",
+    "f": "ף",
+    "k": "ך",
+    "c": "ך",
+    "t": "ת",  # no special final form but kept for completeness
+}
+
+
+def transliterate_to_hebrew(name: str) -> str:
+    """Transliterate a simple English name into Hebrew letters."""
+    result: list[str] = []
+    clean = name.strip().lower()
+
+    for i, ch in enumerate(clean):
+        if ch == " ":
+            result.append(" ")
+            continue
+
+        # Skip a short vowel between two consonants
+        if (
+            ch in {"e", "a"}
+            and 0 < i < len(clean) - 1
+            and clean[i - 1] not in "aeiou"
+            and clean[i + 1] not in "aeiou"
+        ):
+            continue
+
+        heb = LATIN_TO_HEBREW.get(ch)
+        if not heb:
+            continue
+
+        # Use final form if this is the last letter of the word
+        if i == len(clean) - 1 and ch in FINAL_FORMS:
+            heb = FINAL_FORMS[ch]
+
+        result.append(heb)
+
+    return "".join(result)
+
+
+def extract_name_from_email(email: str) -> str | None:
+    """Guess a personal name from an email address."""
+    local = email.split("@", 1)[0]
+    parts = re.split(r"[._-]+", local)
+    parts = [p for p in parts if p.isalpha()]
+    if not parts:
+        return None
+    if len(parts) == 1 and len(parts[0]) > 2 and len(parts[0][-1]) == 1:
+        # Drop single trailing letter (likely a last-name initial)
+        parts[0] = parts[0][:-1]
+    guess = " ".join(p.capitalize() for p in parts)
+    return guess if Contacts.is_valid_name(guess) else None
+
+
+def collect_names(log_file: str = "logs/scraper_io.jsonl", output_file: str = "logs/name_pull.txt") -> set[str]:
+    """Collect names from the JSONL log file and write them to a text file."""
+    names: set[str] = set()
+
+    if os.path.exists(output_file):
+        with open(output_file, encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if line:
+                    names.add(line)
+
+    log_path = Path(log_file)
+    if not log_path.exists():
+        return names
+
+    with open(log_path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                data = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            name = data.get("שם") or data.get("Name")
+            if not name or name.startswith("לא נמצא"):
+                email = data.get("מייל") or data.get("Email")
+                if email:
+                    name = extract_name_from_email(email)
+            if not name:
+                continue
+            if not re.search(r"[א-ת]", name):
+                heb = transliterate_to_hebrew(name)
+                if heb:
+                    name = heb
+            names.add(name)
+
+    with open(output_file, "w", encoding="utf-8") as f:
+        for nm in sorted(names):
+            f.write(nm + "\n")
+
+    return names
+
+
+if __name__ == "__main__":
+    collect_names()

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -75,3 +75,9 @@ def test_invalid_name_digits():
 
 def test_hebrew_name_not_in_db():
     assert not Contacts.is_valid_name("שםשאינובמאגר")
+
+
+def test_english_department_keyword():
+    text = "education john@example.com"
+    c = Contacts(text, "תל אביב")
+    assert c.department == "מחלקת חינוך"

--- a/tests/test_name_pull.py
+++ b/tests/test_name_pull.py
@@ -1,0 +1,39 @@
+import json
+import re
+from pathlib import Path
+
+from name_pull import collect_names, transliterate_to_hebrew, extract_name_from_email
+
+
+def test_collect_names_from_log(tmp_path):
+    log = tmp_path / "io.jsonl"
+    entries = [
+        {"Name": "Dan", "Email": "dan@example.com"},
+        {"Name": "לא נמצא שם", "מייל": "eladr@info.example"},
+        {"Name": "לא נמצא שם", "Email": "danz@example.com"},
+        {"Name": "Dan", "Email": "dan@example.com"},
+    ]
+    with open(log, "w", encoding="utf-8") as f:
+        for e in entries:
+            f.write(json.dumps(e, ensure_ascii=False) + "\n")
+
+    out_file = tmp_path / "names.txt"
+    names = collect_names(str(log), str(out_file))
+
+    assert len(names) == len(set(names))  # unique
+    assert any(re.search(r"[א-ת]", n) for n in names)
+    assert "דן" in names
+
+    with open(out_file, encoding="utf-8") as f:
+        lines = [line.strip() for line in f if line.strip()]
+    assert lines == sorted(names)
+
+
+def test_transliterate_short_vowel():
+    assert transliterate_to_hebrew("Ben") == "בן"
+    assert transliterate_to_hebrew("Dan") == "דן"
+
+
+def test_extract_name_from_email():
+    assert extract_name_from_email("danz@example.com") == "Dan"
+


### PR DESCRIPTION
## Summary
- add a standalone utility `name_pull.py` that gathers unique names from scraper logs and transliterates English names into Hebrew
- pull names from email addresses when missing and ignore trailing single-letter initials
- output collected names into `logs/name_pull.txt`
- add tests for the new utility
- transliteration now skips short 'e' vowels and uses final Hebrew letters
- handle English department keywords in contact parsing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68529699f204832199e73367f97d3870