### PR TITLE
Fix contact counter logging

### DIFF
--- a/src/database_func.py
+++ b/src/database_func.py
@@ -249,11 +249,11 @@ def scrape_with_browser():
     with open(dict_path, "w", encoding="utf-8") as f:
         json.dump(results, f, ensure_ascii=False, indent=2)
 
-    Contacts.contacts = len(results)
     with open(os.path.join(base_dir, "incremental_results", "contacts.json"), "w", encoding="utf-8") as f:
         json.dump(Contacts.contacts, f, ensure_ascii=False, indent=2)
-#dont 
-    logging.info(f"Done scraping all cities into {file_name}, there were {Contacts.contacts}")
+#dont
+    logging.info(
+        f"Done scraping all cities into {file_name}, found {Contacts.contacts} contacts")
     print(" File saved:", dict_path)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- fix total contacts tracking after scraping by removing an overwrite
- log the accumulated `Contacts.contacts` value

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68529e1f98e48321a046a6fd979871ba