### PR TITLE
Integrate ChatGPT-based name guessing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,61 @@
+# Web Scraper
+
+This project scrapes municipal contact information from Israeli websites. It extracts phone numbers, emails and names, then normalizes the data so it can be saved in JSON, CSV or Excel format.
+
+## Features
+
+- Crawls contact pages listed in `data/cities_links.csv` using Playwright
+- Parses free text with heuristics to find personal names, emails and phone numbers
+- Transliterates English names to Hebrew using a local database of Israeli names
+- Optional ChatGPT integration for guessing Hebrew names when heuristics fail
+- Produces logs and incremental JSON files under `logs/` and `data/incremental_results`
+
+## Requirements
+
+- Python 3.11+
+- [Playwright](https://playwright.dev/python/) for browser automation
+- `pandas` for data handling
+- `beautifulsoup4` and `requests` for page parsing
+- `openpyxl` to export Excel files
+- `nameparser` for name parsing helpers
+- `openai` (optional) if using ChatGPT
+
+Install dependencies with:
+
+```bash
+pip install pandas playwright beautifulsoup4 requests openpyxl nameparser openai
+playwright install
+```
+
+## Usage
+
+Run the main scraper which fetches contact pages and stores results:
+
+```bash
+python src/database_func.py
+```
+
+After scraping, create consolidated output files:
+
+```bash
+python src/all_contacts.py
+```
+
+Unique names can be extracted from the logs with:
+
+```bash
+python src/name_pull.py
+```
+
+## ChatGPT Integration
+
+Set the `OPENAI_API_KEY` environment variable to allow the scraper to query ChatGPT when it cannot determine a Hebrew name. This step is optional; without the variable the code falls back to built‑in heuristics.
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+pytest -q
+```
+

--- a/src/chatgpt_name.py
+++ b/src/chatgpt_name.py
@@ -1,0 +1,45 @@
+import os
+import logging
+
+# Attempt to import openai when available
+try:
+    import openai  # type: ignore
+except Exception:  # pragma: no cover - openai may not be installed
+    openai = None
+
+
+def guess_hebrew_name(text: str) -> str | None:
+    """Return the best Hebrew personal name for the given text using ChatGPT.
+
+    The OpenAI API key is read from the ``OPENAI_API_KEY`` environment
+    variable. If the key or the ``openai`` package is missing, ``None`` is
+    returned.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or not text or openai is None:
+        return None
+
+    openai.api_key = api_key
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": "Return the best Hebrew personal name for the provided text.",
+                },
+                {"role": "user", "content": text},
+            ],
+            max_tokens=4,
+            temperature=0,
+        )
+    except Exception:
+        logging.exception("OpenAI request failed")
+        return None
+
+    try:
+        result = response["choices"][0]["message"]["content"].strip()
+    except Exception:
+        return None
+
+    return result or None

--- a/tests/test_chatgpt_name.py
+++ b/tests/test_chatgpt_name.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+import types
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+import chatgpt_name
+from jobs import Contacts
+
+
+def test_guess_hebrew_name(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fake_create(**kwargs):
+        return {"choices": [{"message": {"content": "דן"}}]}
+
+    dummy = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(chatgpt_name, "openai", dummy)
+
+    assert chatgpt_name.guess_hebrew_name("Dan") == "דן"
+
+
+def test_contacts_chatgpt_fallback(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fake_create(**kwargs):
+        return {"choices": [{"message": {"content": "דן"}}]}
+
+    dummy = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(chatgpt_name, "openai", dummy)
+
+    c = Contacts("some text without name", "תל אביב")
+    assert c.name == "דן"


### PR DESCRIPTION
## Summary
- add `chatgpt_name` helper using OpenAI to guess Hebrew names
- call ChatGPT fallback in `collect_names` and `Contacts.parse`
- document `OPENAI_API_KEY` environment variable
- document project usage and dependencies in README
- test ChatGPT integration with mocked API

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685420341c008321a2d52dc85b099be2