### PR TITLE
Add skip handling for string site profiles

### DIFF
--- a/src/database_func.py
+++ b/src/database_func.py
@@ -186,6 +186,10 @@ def process_city(row, existing_data):
 
     hostname = urlparse(url).hostname
     profile = site_profiles.get(hostname, {})
+    if isinstance(profile, str):
+        profile = {"skip": True, "reason": profile}
+        site_profiles[hostname] = profile
+
     if profile.get("skip"):
         logging.info(
             f"[SKIP] {city}: marked to skip ({profile.get('reason', 'no reason')})"

--- a/tests/test_database_func.py
+++ b/tests/test_database_func.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import types
+
+# ensure src directory on path
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+# provide a dummy playwright module so database_func can be imported without
+# installing the real dependency
+fake_sync = types.ModuleType("sync_api")
+fake_sync.sync_playwright = lambda: None
+fake_playwright = types.ModuleType("playwright")
+fake_playwright.sync_api = fake_sync
+sys.modules.setdefault("playwright", fake_playwright)
+sys.modules.setdefault("playwright.sync_api", fake_sync)
+
+# minimal pandas stub for pd.isna
+fake_pd = types.SimpleNamespace(isna=lambda x: x != x or x is None)
+sys.modules.setdefault("pandas", fake_pd)
+
+# minimal nameparser stub
+fake_nameparser = types.ModuleType("nameparser")
+fake_nameparser.HumanName = lambda x: x
+sys.modules.setdefault("nameparser", fake_nameparser)
+
+import database_func
+
+
+def test_process_city_string_profile(monkeypatch):
+    profiles = {"example.com": "deprecated"}
+    monkeypatch.setattr(database_func, "site_profiles", profiles)
+    row = {"עיר": "Example", "קישור": "http://example.com"}
+
+    city, data = database_func.process_city(row, {})
+
+    assert city == "Example"
+    assert data == {}
+    assert database_func.site_profiles["example.com"]["skip"] is True


### PR DESCRIPTION
## Summary
- normalize string values in `site_profiles` when processing a city
- add regression test for string site profile entries

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552500bed08321bfd120753c1c6464