### PR TITLE
Handle NaN URLs in process_city

### DIFF
--- a/src/database_func.py
+++ b/src/database_func.py
@@ -175,10 +175,14 @@ def extract_relevant_contacts_from_text(text, city_name):
 
 def process_city(row, existing_data):
     city = row["עיר"]
+
     url = row["קישור"]
     # במקרה שיש רווח כי הוכנס בטעות זה יטפל בזה לא למחוק!
-    if url.startswith(" "):
+    if isinstance(url, str) and url.startswith(" "):
         url = url.strip()
+
+    if str(url).lower() == "nan":
+        url = None
 
     if pd.isna(url) or city in existing_data and existing_data[city]:
         logging.info(f"[SKIP] {city}: Already scraped or no URL")

--- a/tests/test_process_city.py
+++ b/tests/test_process_city.py
@@ -1,0 +1,35 @@
+import sys
+import types
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+
+dummy_pandas = types.ModuleType("pandas")
+dummy_pandas.isna = lambda x: x is None
+sys.modules.setdefault("pandas", dummy_pandas)
+
+dummy_nameparser = types.ModuleType("nameparser")
+dummy_nameparser.HumanName = lambda x: x
+sys.modules.setdefault("nameparser", dummy_nameparser)
+
+dummy_sync_api = types.ModuleType("playwright.sync_api")
+dummy_sync_api.sync_playwright = lambda *a, **k: None
+dummy_playwright = types.ModuleType("playwright")
+dummy_playwright.sync_api = dummy_sync_api
+sys.modules.setdefault("playwright", dummy_playwright)
+sys.modules.setdefault("playwright.sync_api", dummy_sync_api)
+
+import database_func
+
+
+def test_process_city_skips_nan_url(monkeypatch):
+    row = {"עיר": "TestCity", "קישור": " NaN "}
+
+    def fake_sync_playwright(*args, **kwargs):
+        raise AssertionError("sync_playwright should not be called")
+
+    monkeypatch.setattr(database_func, "sync_playwright", fake_sync_playwright)
+
+    city, data = database_func.process_city(row, {})
+    assert city == "TestCity"
+    assert data == {}


### PR DESCRIPTION
## Summary
- handle "NaN" URL values in `process_city`
- add regression test for skipping rows with NaN URLs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552502914883219927c4189f2db5d0