### PR TITLE
Add ChatGPT department inference

### DIFF
--- a/src/chatgpt_name.py
+++ b/src/chatgpt_name.py
@@ -43,3 +43,55 @@ def guess_hebrew_name(text: str) -> str | None:
         return None
 
     return result or None
+
+
+def guess_hebrew_department(
+    text: str | None = None, url: str | None = None
+) -> str | None:
+    """Return the best Hebrew department name for the given text or URL using ChatGPT.
+
+    The OpenAI API key is read from the ``OPENAI_API_KEY`` environment
+    variable. If the key or the ``openai`` package is missing, ``None`` is
+    returned.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key or openai is None:
+        return None
+
+    prompt_parts = []
+    if text:
+        prompt_parts.append(text)
+    if url:
+        prompt_parts.append(f"URL: {url}")
+
+    if not prompt_parts:
+        return None
+
+    prompt = "\n".join(prompt_parts)
+
+    openai.api_key = api_key
+    try:
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "Return the best Hebrew department name for the provided text or URL."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            max_tokens=6,
+            temperature=0,
+        )
+    except Exception:
+        logging.exception("OpenAI request failed")
+        return None
+
+    try:
+        result = response["choices"][0]["message"]["content"].strip()
+    except Exception:
+        return None
+
+    return result or None

--- a/src/database_func.py
+++ b/src/database_func.py
@@ -135,7 +135,7 @@ def extract_text_from_url(page, url):
         return ""
 
 
-def extract_relevant_contacts_from_text(text, city_name):
+def extract_relevant_contacts_from_text(text, city_name, source_url=None):
     people = {}
     lines = text.split("\n")
 
@@ -145,7 +145,7 @@ def extract_relevant_contacts_from_text(text, city_name):
             continue
 
         if "@" in line or re.search(r"0[2-9]\d{7}", line):
-            contact_obj = Contacts(line, city_name)
+            contact_obj = Contacts(line, city_name, url=source_url)
 
             if not contact_obj.name and contact_obj.email:
                 name_guess = contact_obj.email.split("@")[0]
@@ -226,7 +226,7 @@ def process_city(row, existing_data):
                 ) as f:
                     f.write(text)
 
-                contact_info = extract_relevant_contacts_from_text(text, city)
+                contact_info = extract_relevant_contacts_from_text(text, city, link)
                 extracted_data = contact_info.get(city, {})
                 city_data.update(extracted_data)
 

--- a/src/jobs.py
+++ b/src/jobs.py
@@ -5,7 +5,7 @@ import urllib.parse
 from pathlib import Path
 from difflib import get_close_matches
 
-from chatgpt_name import guess_hebrew_name
+from chatgpt_name import guess_hebrew_name, guess_hebrew_department
 
 
 LATIN_TO_HEBREW = {
@@ -150,6 +150,15 @@ def _dept_from_email(email: str) -> str | None:
     return None
 
 
+def _dept_from_url(url: str) -> str | None:
+    """Guess department from a URL using ENGLISH_DEPT_KEYWORDS."""
+    lower = url.lower()
+    for keyword, dept in ENGLISH_DEPT_KEYWORDS.items():
+        if keyword in lower:
+            return dept
+    return None
+
+
 class Contacts:
     contacts = 0
     # Common phrases that might look like names but aren't
@@ -201,9 +210,10 @@ class Contacts:
                 return False
         return True
 
-    def __init__(self, raw_text, city):
+    def __init__(self, raw_text, city, url: str | None = None):
         self.raw_text = raw_text
         self.city = city
+        self.url = url
         self.name = None
         self.role = None
         self.department = None
@@ -268,6 +278,16 @@ class Contacts:
 
         if not self.department and self.email:
             guessed = _dept_from_email(self.email)
+            if guessed:
+                self.department = guessed
+
+        if not self.department and self.url:
+            guessed = _dept_from_url(self.url)
+            if guessed:
+                self.department = guessed
+
+        if not self.department:
+            guessed = guess_hebrew_department(self.raw_text, self.url)
             if guessed:
                 self.department = guessed
 

--- a/tests/test_chatgpt_name.py
+++ b/tests/test_chatgpt_name.py
@@ -35,3 +35,39 @@ def test_contacts_chatgpt_fallback(monkeypatch):
 
     c = Contacts("some text without name", "תל אביב")
     assert c.name == "דן"
+
+
+def test_guess_hebrew_department(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fake_create(**kwargs):
+        return {"choices": [{"message": {"content": "מחלקת תרבות"}}]}
+
+    dummy = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(chatgpt_name, "openai", dummy)
+
+    result = chatgpt_name.guess_hebrew_department(
+        "culture text", "http://ex.com/culture"
+    )
+    assert result == "מחלקת תרבות"
+
+
+def test_contacts_chatgpt_department_fallback(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fake_create(**kwargs):
+        sys_msg = kwargs["messages"][0]["content"]
+        if "department" in sys_msg:
+            return {"choices": [{"message": {"content": "מחלקת חינוך"}}]}
+        return {"choices": [{"message": {"content": "דן"}}]}
+
+    dummy = types.SimpleNamespace(
+        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    )
+    monkeypatch.setattr(chatgpt_name, "openai", dummy)
+
+    c = Contacts("no department text", "תל אביב", url="http://ex.com/edu")
+    assert c.department == "מחלקת חינוך"
+    assert c.name == "דן"


### PR DESCRIPTION
## Summary
- infer departments with ChatGPT
- check page URL when parsing contact info
- tests for ChatGPT department helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685528df669c832180db2cb772aac0a9