### PR TITLE
Fix pycache ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 iframe_page.html
-__Pycach__/
+**/__pycache__/
 logs/
 incremental_results/
 __pycache__/


### PR DESCRIPTION
## Summary
- fix pattern for pycache directories in `.gitignore`
- clean up stray `__pycache__` folders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685546d175848321803ed493754e68af