### PR TITLE
Improve AI-only translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,12 @@ Unique names can be extracted from the logs with:
 python src/name_pull.py
 ```
 
+The entire workflow can be triggered with one command using `main.sh`:
+
+```bash
+./main.sh
+```
+
 ## Output
 
 `database_func.py` saves the results in the repository root under the name you
@@ -67,7 +73,7 @@ The JSON will then be available at `./output/contacts.json`.
 
 ## ChatGPT Integration
 
-Set the `OPENAI_API_KEY` environment variable to allow the scraper to query ChatGPT when it cannot determine a Hebrew name. This step is optional; without the variable the code falls back to built‑in heuristics.
+Set the `OPENAI_API_KEY` environment variable to allow the scraper to query ChatGPT when it cannot determine a Hebrew name or department. This key is used by the scraping code and by `name_pull.py` when refining names from the log file. Without the variable the code falls back to built‑in heuristics.
 
 ## Testing
 

--- a/main.sh
+++ b/main.sh
@@ -1,3 +1,16 @@
 #!/bin/bash
-# Save contacts to output/contacts.json by default
-python3 ./src/database_func.py output/contacts.json
+# Run scraping, name translation and CSV/Excel conversion automatically
+
+set -e
+
+# Location of the scraped JSON
+OUT="output/contacts.json"
+
+# 1. Scrape all sites and apply ChatGPT translations
+python3 ./src/database_func.py "$OUT"
+
+# 2. Convert the JSON into CSV and Excel files
+python3 ./src/all_contacts.py "$OUT"
+
+# 3. Extract unique names from the logs
+python3 ./src/name_pull.py

--- a/src/all_contacts.py
+++ b/src/all_contacts.py
@@ -1,28 +1,51 @@
+"""Generate CSV/Excel contact lists from the scraped JSON file."""
+
 import json
+from pathlib import Path
+
 import pandas as pd
 
-# Load the JSON data
-with open("smart_contacts.json", encoding="utf-8") as f:
-    contacts = json.load(f)
+BASE_DIR = Path(__file__).resolve().parents[1]
 
-# Flatten into rows
-rows = []
-for city, people in contacts.items():
-    for name, info in people.items():
-        rows.append({
-            "עיר": city,
-            "שם": name,
-            "טלפון": info.get("phone"),
-            "אימייל": info.get("email"),
-            "תפקיד": info.get("job_title"),
-            "מחלקה": info.get("department")
-        })
 
-# Save to CSV
-df = pd.DataFrame(rows)
-df.to_csv("all_contacts.csv", index=False, encoding="utf-8-sig")
-print("✅ הקובץ נשמר: all_contacts.csv")
+def load_contacts(path: Path | None = None) -> dict:
+    """Load contacts JSON from ``path`` or the default data directory."""
+    if path is None:
+        path = BASE_DIR / "data" / "smart_contacts.json"
+    with path.open(encoding="utf-8") as f:
+        return json.load(f)
 
-# Save to Excel
-df.to_excel("all_contacts.xlsx", index=False, engine="openpyxl")
-print(" הקובץ נשמר גם כ־ all_contacts.xlsx")
+def save_outputs(df: pd.DataFrame) -> None:
+    df.to_csv("all_contacts.csv", index=False, encoding="utf-8-sig")
+    print("✅ הקובץ נשמר: all_contacts.csv")
+
+    df.to_excel("all_contacts.xlsx", index=False, engine="openpyxl")
+    print(" הקובץ נשמר גם כ־ all_contacts.xlsx")
+
+
+def main(json_path: str | None = None) -> None:
+    data = load_contacts(Path(json_path) if json_path else None)
+
+    rows = []
+    for city, people in data.items():
+        for name, info in people.items():
+            rows.append(
+                {
+                    "עיר": city,
+                    "שם": name,
+                    "טלפון": info.get("phone"),
+                    "אימייל": info.get("email"),
+                    "תפקיד": info.get("job_title"),
+                    "מחלקה": info.get("department"),
+                }
+            )
+
+    df = pd.DataFrame(rows)
+    save_outputs(df)
+
+
+if __name__ == "__main__":
+    import sys
+
+    path_arg = sys.argv[1] if len(sys.argv) > 1 else None
+    main(path_arg)

--- a/src/collect_names.py
+++ b/src/collect_names.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 import json
-import os
 from pathlib import Path
 
 
@@ -34,4 +33,3 @@ def collect_names(base_dir: Path | str | None = None) -> None:
     with output_file.open("w", encoding="utf-8") as f:
         for name in sorted(names):
             f.write(f"{name}\n")
-

--- a/src/database_func.py
+++ b/src/database_func.py
@@ -12,7 +12,6 @@ from jobs import Contacts
 from datafunc import apply_hebrew_transliteration
 from nameparser import HumanName
 from collect_names import collect_names
-import time
 
 base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 

--- a/tests/test_datafunc.py
+++ b/tests/test_datafunc.py
@@ -1,10 +1,12 @@
 import json
 from pathlib import Path
 
+import jobs
 from datafunc import apply_hebrew_transliteration
 
 
-def test_transliteration_updates_file(tmp_path):
+def test_transliteration_updates_file(tmp_path, monkeypatch):
+    monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: "יוחנן")
     data = {
         "אלעד": {
             "john": {"שם": "john", "מייל": "john@example.com"}
@@ -17,4 +19,4 @@ def test_transliteration_updates_file(tmp_path):
 
     loaded = json.loads(file.read_text(encoding="utf-8"))
     assert "john" not in loaded["אלעד"]
-    assert "גוהן" in loaded["אלעד"]
+    assert "יוחנן" in loaded["אלעד"]

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -4,6 +4,7 @@ from pathlib import Path
 # Ensure src directory is on sys.path
 sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
+import jobs
 from jobs import Contacts
 
 
@@ -51,7 +52,8 @@ def test_non_name_phrase_email_address():
     assert c.name == "לא נמצא שם"
 
 
-def test_name_from_email():
+def test_name_from_email(monkeypatch):
+    monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: "נוא דרי")
     text = "noa_adari@example.org"
     c = Contacts(text, "אשקלון")
     assert c.name == "נוא דרי"
@@ -78,7 +80,8 @@ def test_hebrew_name_not_in_db():
     assert Contacts.is_valid_name("שםשאינובמאגר")
 
 
-def test_trailing_char_single_segment():
+def test_trailing_char_single_segment(monkeypatch):
+    monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: "נואם")
     text = "noamk@example.com"
     c = Contacts(text, "תל אביב")
     assert c.name == "נואם"

--- a/tests/test_name_pull.py
+++ b/tests/test_name_pull.py
@@ -2,10 +2,12 @@ import json
 import re
 from pathlib import Path
 
+import name_pull
 from name_pull import collect_names, transliterate_to_hebrew, extract_name_from_email
 
 
-def test_collect_names_from_log(tmp_path):
+def test_collect_names_from_log(tmp_path, monkeypatch):
+    monkeypatch.setattr(name_pull, "guess_hebrew_name", lambda text: "דן")
     log = tmp_path / "io.jsonl"
     entries = [
         {"Name": "Dan", "Email": "dan@example.com"},
@@ -29,7 +31,14 @@ def test_collect_names_from_log(tmp_path):
     assert lines == sorted(names)
 
 
-def test_transliterate_short_vowel():
+def test_transliterate_short_vowel(monkeypatch):
+    mapping = {"Ben": "בן", "Dan": "דן", "Noam": "נואם"}
+
+    def fake_guess(name):
+        return mapping.get(name)
+
+    monkeypatch.setattr(name_pull, "guess_hebrew_name", fake_guess)
+
     assert transliterate_to_hebrew("Ben") == "בן"
     assert transliterate_to_hebrew("Dan") == "דן"
     assert transliterate_to_hebrew("Noam") == "נואם"


### PR DESCRIPTION
## Summary
- rely solely on ChatGPT to convert English names to Hebrew
- clean up unused transliteration code
- adjust tests to mock ChatGPT name guesses
- add main.sh wrapper to run scraping and conversions in one go

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68557c960f6c83218630706eed0e87c1