### PR TITLE
Update ChatGPT API usage

### DIFF
--- a/src/chatgpt_name.py
+++ b/src/chatgpt_name.py
@@ -19,9 +19,9 @@ def guess_hebrew_name(text: str) -> str | None:
     if not api_key or not text or openai is None:
         return None
 
-    openai.api_key = api_key
     try:
-        response = openai.ChatCompletion.create(
+        client = openai.OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {
@@ -38,7 +38,10 @@ def guess_hebrew_name(text: str) -> str | None:
         return None
 
     try:
-        result = response["choices"][0]["message"]["content"].strip()
+        if isinstance(response, dict):
+            result = response["choices"][0]["message"]["content"].strip()
+        else:
+            result = response.choices[0].message.content.strip()
     except Exception:
         return None
 
@@ -69,9 +72,9 @@ def guess_hebrew_department(
 
     prompt = "\n".join(prompt_parts)
 
-    openai.api_key = api_key
     try:
-        response = openai.ChatCompletion.create(
+        client = openai.OpenAI(api_key=api_key)
+        response = client.chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {
@@ -90,7 +93,10 @@ def guess_hebrew_department(
         return None
 
     try:
-        result = response["choices"][0]["message"]["content"].strip()
+        if isinstance(response, dict):
+            result = response["choices"][0]["message"]["content"].strip()
+        else:
+            result = response.choices[0].message.content.strip()
     except Exception:
         return None
 

--- a/tests/test_chatgpt_name.py
+++ b/tests/test_chatgpt_name.py
@@ -14,9 +14,12 @@ def test_guess_hebrew_name(monkeypatch):
     def fake_create(**kwargs):
         return {"choices": [{"message": {"content": "דן"}}]}
 
-    dummy = types.SimpleNamespace(
-        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=fake_create)
+        )
     )
+    dummy = types.SimpleNamespace(OpenAI=lambda **kwargs: client)
     monkeypatch.setattr(chatgpt_name, "openai", dummy)
 
     assert chatgpt_name.guess_hebrew_name("Dan") == "דן"
@@ -28,9 +31,12 @@ def test_contacts_chatgpt_fallback(monkeypatch):
     def fake_create(**kwargs):
         return {"choices": [{"message": {"content": "דן"}}]}
 
-    dummy = types.SimpleNamespace(
-        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=fake_create)
+        )
     )
+    dummy = types.SimpleNamespace(OpenAI=lambda **kwargs: client)
     monkeypatch.setattr(chatgpt_name, "openai", dummy)
 
     c = Contacts("some text without name", "תל אביב")
@@ -43,9 +49,12 @@ def test_guess_hebrew_department(monkeypatch):
     def fake_create(**kwargs):
         return {"choices": [{"message": {"content": "מחלקת תרבות"}}]}
 
-    dummy = types.SimpleNamespace(
-        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=fake_create)
+        )
     )
+    dummy = types.SimpleNamespace(OpenAI=lambda **kwargs: client)
     monkeypatch.setattr(chatgpt_name, "openai", dummy)
 
     result = chatgpt_name.guess_hebrew_department(
@@ -63,9 +72,12 @@ def test_contacts_chatgpt_department_fallback(monkeypatch):
             return {"choices": [{"message": {"content": "מחלקת חינוך"}}]}
         return {"choices": [{"message": {"content": "דן"}}]}
 
-    dummy = types.SimpleNamespace(
-        ChatCompletion=types.SimpleNamespace(create=fake_create)
+    client = types.SimpleNamespace(
+        chat=types.SimpleNamespace(
+            completions=types.SimpleNamespace(create=fake_create)
+        )
     )
+    dummy = types.SimpleNamespace(OpenAI=lambda **kwargs: client)
     monkeypatch.setattr(chatgpt_name, "openai", dummy)
 
     c = Contacts("no department text", "תל אביב", url="http://ex.com/edu")


### PR DESCRIPTION
## Summary
- update `chatgpt_name` to use `openai.OpenAI` client
- adjust tests for new client interface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855a1957e7c8321bd9b629b34c4785e