### PR TITLE
Fix email name extraction edge case

### DIFF
--- a/src/name_pull.py
+++ b/src/name_pull.py
@@ -24,7 +24,7 @@ def extract_name_from_email(email: str) -> str | None:
     parts = [p for p in parts if p.isalpha()]
     if not parts:
         return None
-    if len(parts) == 1 and len(parts[0]) > 2 and len(parts[0][-1]) == 1:
+    if len(parts) == 1 and len(parts[0]) > 3 and parts[0][-1].isalpha():
         # Drop single trailing letter (likely a last-name initial)
         parts[0] = parts[0][:-1]
     guess = " ".join(p.capitalize() for p in parts)

--- a/tests/test_name_pull.py
+++ b/tests/test_name_pull.py
@@ -46,3 +46,8 @@ def test_transliterate_short_vowel(monkeypatch):
 
 def test_extract_name_from_email():
     assert extract_name_from_email("danz@example.com") == "Dan"
+
+
+def test_extract_name_from_email_short_name():
+    """Ensure short usernames aren't truncated."""
+    assert extract_name_from_email("dan@example.com") == "Dan"


### PR DESCRIPTION
## Summary
- fix trailing initial logic in `extract_name_from_email`
- ensure short usernames aren't truncated in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855baab2fac8321bd7071e53d942d6e