### PR TITLE
Improve name extraction

### DIFF
--- a/tests/test_chatgpt_name.py
+++ b/tests/test_chatgpt_name.py
@@ -40,7 +40,7 @@ def test_contacts_chatgpt_fallback(monkeypatch):
     monkeypatch.setattr(chatgpt_name, "openai", dummy)
 
     c = Contacts("some text without name", "תל אביב")
-    assert c.name == "דן"
+    assert c.name == "לא נמצא שם"
 
 
 def test_guess_hebrew_department(monkeypatch):
@@ -82,4 +82,4 @@ def test_contacts_chatgpt_department_fallback(monkeypatch):
 
     c = Contacts("no department text", "תל אביב", url="http://ex.com/edu")
     assert c.department == "מחלקת חינוך"
-    assert c.name == "דן"
+    assert c.name == "לא נמצא שם"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -87,6 +87,13 @@ def test_trailing_char_single_segment(monkeypatch):
     assert c.name == "נואם"
 
 
+def test_english_name_from_text(monkeypatch):
+    monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: "יוחנן דו")
+    text = "Contact John Doe for info"
+    c = Contacts(text, "תל אביב")
+    assert c.name == "יוחנן דו"
+
+
 def test_english_department_keyword():
     text = "education john@example.com"
     c = Contacts(text, "תל אביב")


### PR DESCRIPTION
## Summary
- refine algorithm to only call ChatGPT after a name candidate is found
- drop AI fallback when no name is parsed
- handle English names that come after leading text
- adjust tests for the new behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68567b9d5d288321b3424a0596dafc3a