### PR TITLE
Extend department keyword mapping

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -28,12 +28,20 @@ ENGLISH_DEPT_KEYWORDS = {
     "absorption": "מחלקת קליטה",
     "environment": "מחלקת איכות סביבה",
     "veterans": "מחלקת אזרחים וותיקים",
+    "sport": "מחלקת ספורט",
+    "sports": "מחלקת ספורט",
+    "finance": "מחלקת כספים",
+    "finances": "מחלקת כספים",
+    "engineering": "מחלקת הנדסה",
+    "transport": "מחלקת תחבורה",
+    "traffic": "מחלקת תחבורה",
+    "security": "מחלקת ביטחון",
 }
 
 
 def _dept_from_email(email: str) -> str | None:
     """Guess department from email address using ENGLISH_DEPT_KEYWORDS."""
-    lower = email.lower()
+    lower = re.sub(r"[-_.]+", " ", email.lower())
     for keyword, dept in ENGLISH_DEPT_KEYWORDS.items():
         if keyword in lower:
             return dept
@@ -42,7 +50,7 @@ def _dept_from_email(email: str) -> str | None:
 
 def _dept_from_url(url: str) -> str | None:
     """Guess department from a URL using ENGLISH_DEPT_KEYWORDS."""
-    lower = url.lower()
+    lower = re.sub(r"[-_.]+", " ", url.lower())
     for keyword, dept in ENGLISH_DEPT_KEYWORDS.items():
         if keyword in lower:
             return dept

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -104,3 +104,21 @@ def test_department_from_email():
     text = "john@youngdept.org"
     c = Contacts(text, "תל אביב")
     assert c.department == "מחלקת צעירים"
+
+
+def test_english_department_keyword_sports():
+    text = "sports jane@example.com"
+    c = Contacts(text, "תל אביב")
+    assert c.department == "מחלקת ספורט"
+
+
+def test_department_from_email_engineering():
+    text = "bob@engineering-city.org"
+    c = Contacts(text, "תל אביב")
+    assert c.department == "מחלקת הנדסה"
+
+
+def test_department_from_url_finance():
+    text = "bob@example.com"
+    c = Contacts(text, "תל אביב", url="https://city.gov.il/finance/team")
+    assert c.department == "מחלקת כספים"


### PR DESCRIPTION
## Summary
- extend `ENGLISH_DEPT_KEYWORDS` with new terms
- normalize separators when guessing department from emails and URLs
- add tests for sports, engineering, and finance department detection

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ac7d8a10832194e3ce745ca28c6f