### PR TITLE
Improve contact text parsing

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -104,3 +104,23 @@ def test_department_from_email():
     text = "john@youngdept.org"
     c = Contacts(text, "תל אביב")
     assert c.department == "מחלקת צעירים"
+
+
+def test_clean_text_punctuation():
+    assert jobs._clean_text(" שלום,  עולם ; ") == "שלום עולם"
+
+
+def test_combined_hyphen(monkeypatch):
+    monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: n)
+    text = "משה כהן-מנהל מחלקת תרבות moshe@ex.com"
+    c = Contacts(text, "תל אביב")
+    assert c.name == "משה כהן"
+    assert c.role.startswith("מנהל")
+
+
+def test_combined_parentheses(monkeypatch):
+    monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: n)
+    text = "יפעת לוי (רכזת צעירים) 050-1111111"
+    c = Contacts(text, "תל אביב")
+    assert c.name == "יפעת לוי"
+    assert c.role.startswith("רכזת")


### PR DESCRIPTION
## Summary
- make `_clean_text` strip punctuation
- detect and parse combined name/role lines
- test punctuation cleanup and hyphen/parentheses splitting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856ac7f42948321aa1c38800ab1027b