### PR TITLE
Improve name extraction heuristics

### DIFF
--- a/tests/test_chatgpt_name.py
+++ b/tests/test_chatgpt_name.py
@@ -6,6 +6,7 @@ sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
 
 import chatgpt_name
 from jobs import Contacts
+import jobs
 
 
 def test_guess_hebrew_name(monkeypatch):
@@ -40,7 +41,7 @@ def test_contacts_chatgpt_fallback(monkeypatch):
     monkeypatch.setattr(chatgpt_name, "openai", dummy)
 
     c = Contacts("some text without name", "תל אביב")
-    assert c.name == "לא נמצא שם"
+    assert c.name == "דן"
 
 
 def test_guess_hebrew_department(monkeypatch):
@@ -82,4 +83,17 @@ def test_contacts_chatgpt_department_fallback(monkeypatch):
 
     c = Contacts("no department text", "תל אביב", url="http://ex.com/edu")
     assert c.department == "מחלקת חינוך"
-    assert c.name == "לא נמצא שם"
+    assert c.name == "דן"
+
+
+def test_no_chatgpt_when_hebrew_name(monkeypatch):
+    """Ensure Hebrew names are kept without calling ChatGPT."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+
+    def fail(*args, **kwargs):
+        raise AssertionError("should not call")
+
+    monkeypatch.setattr(jobs, "guess_hebrew_name", fail)
+
+    c = Contacts("דני 050-1234567", "תל אביב")
+    assert c.name == "דני"


### PR DESCRIPTION
## Summary
- fallback to regex when searching for department names
- use scraped name unless no Hebrew found
- let ChatGPT guess names only as a last resort
- update tests for new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68591945e28c832184702b0b98bf5962