### PR TITLE
Improve email phrase detection

### DIFF
--- a/src/jobs.py
+++ b/src/jobs.py
@@ -6,9 +6,7 @@ from chatgpt_name import guess_hebrew_name, guess_hebrew_department
 from gov_names import load_names
 
 
-CACHE_FILE = (
-    Path(__file__).resolve().parents[1] / "data" / "translation_cache.json"
-)
+CACHE_FILE = Path(__file__).resolve().parents[1] / "data" / "translation_cache.json"
 _translation_cache: dict[str, str] | None = None
 _gov_names: dict[str, str] | None = None
 
@@ -123,6 +121,9 @@ class Contacts:
     NON_NAME_PHRASES = [
         "לפרטים נוספים",
         "כתובת דואר אלקטרוני",
+        "דואר אלקטרוני",
+        'דוא"ל',
+        "דוא",
         "לשכה",
         "אגף",
     ]
@@ -312,15 +313,13 @@ class Contacts:
             if not self.name and self.email:
                 # Skip when text contains known non-name phrases
                 if not any(
-                    phrase in self.raw_text
-                    for phrase in Contacts.NON_NAME_PHRASES
+                    phrase in self.raw_text for phrase in Contacts.NON_NAME_PHRASES
                 ):
                     local = self.email.split("@")[0]
                     parts = re.split(r"[._-]+", local)
                     parts = [p for p in parts if p.isalpha()]
                     if parts and all(
-                        p.lower() not in Contacts.NON_PERSONAL_USERNAMES
-                        for p in parts
+                        p.lower() not in Contacts.NON_PERSONAL_USERNAMES for p in parts
                     ):
                         if len(parts) == 1 and parts[0][-1].isalpha():
                             parts[0] = parts[0][:-1]
@@ -333,9 +332,7 @@ class Contacts:
             if guess:
                 self.name = guess
             else:
-                self.name = (
-                    f"לא נמצא שם ({self.role})" if self.role else "לא נמצא שם"
-                )
+                self.name = f"לא נמצא שם ({self.role})" if self.role else "לא נמצא שם"
         else:
             if not re.search(r"[א-ת]", self.name):
                 guess = guess_hebrew_name(self.name)

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -52,6 +52,18 @@ def test_non_name_phrase_email_address():
     assert c.name == "לא נמצא שם"
 
 
+def test_non_name_phrase_short_email():
+    text = "דואר אלקטרוני info@test.com"
+    c = Contacts(text, "באר שבע")
+    assert c.name == "לא נמצא שם"
+
+
+def test_non_name_phrase_dual_email():
+    text = 'דוא"ל info@test.com'
+    c = Contacts(text, "באר שבע")
+    assert c.name == "לא נמצא שם"
+
+
 def test_name_from_email(monkeypatch):
     monkeypatch.setattr(jobs, "guess_hebrew_name", lambda n: "נוא דרי")
     text = "noa_adari@example.org"


### PR DESCRIPTION
## Summary
- refine NON_NAME_PHRASES in `Contacts`
- ensure generic email phrases don't get parsed as names
- test the new behaviour

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68597a9d6f60832194a02396c4934032